### PR TITLE
extracting attributes to separate styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,9 +149,10 @@ function extractStyle (file, classNamePrefix) {
         }
         var componentClassName = styleToClassname[style];
         $item.removeAttr('style');
+        $item.addClass(componentClassName);
     });
     file.contents = new Buffer($.html());
-    return styleBlocks.text()+_.map(styleToClassname,function(className,style){
+    return styleBlocks.text().replace(/<!\[CDATA\[([^\]]+)]\]>/ig, "$1")+_.map(styleToClassname,function(className,style){
         return '.' + className + '{' + style + '}';
     }).join('\n');
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./test/test.js"
   },
   "keywords": [
     "svg",

--- a/test/src/similar-question-v3.svg
+++ b/test/src/similar-question-v3.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="48px"
+   height="48px"
+   viewBox="0 0 48 48"
+   enable-background="new 0 0 48 48"
+   xml:space="preserve"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="similar question v2.svg"><metadata
+     id="metadata25"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs23" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1035"
+     id="namedview21"
+     showgrid="false"
+     inkscape:zoom="9.8333335"
+     inkscape:cx="21.497997"
+     inkscape:cy="23.102344"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><g
+     id="g2994"
+     transform="translate(-0.6,12)"><path
+       d="M 18.421198,24 H 2.5788022 C 2.2593034,24 2,23.741275 2,23.421198 V 2.6202036 C 2,2.3007047 2.2593034,2.0414013 2.5788022,2.0414013 H 18.421198 C 18.741275,2.0414013 19,2.3007047 19,2.6202036 V 23.421198 C 19,23.741275 18.741275,24 18.421198,24 z M 3.1576044,22.842396 H 17.842396 V 3.1990058 H 3.1576044 V 22.842396 z"
+       id="path5"
+       inkscape:connector-curvature="0" /><text
+       sodipodi:linespacing="125%"
+       id="text3379"
+       y="10.451347"
+       x="5.0458045"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       xml:space="preserve"><tspan
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto"
+         y="10.451347"
+         x="5.0458045"
+         id="tspan3381"
+         sodipodi:role="line">x=1</tspan><tspan
+         id="tspan3389"
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto"
+         y="19.201347"
+         x="5.0458045"
+         sodipodi:role="line">y=3</tspan><tspan
+         id="tspan3385"
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto"
+         y="27.951347"
+         x="5.0458045"
+         sodipodi:role="line" /></text>
+</g><g
+     id="g3001"
+     transform="translate(0.7,-10)"><path
+       inkscape:connector-curvature="0"
+       id="path3031"
+       d="M 45.421198,46 H 29.578802 C 29.259304,46 29,45.741276 29,45.421198 V 24.620204 c 0,-0.319499 0.259304,-0.578802 0.578802,-0.578802 H 45.421198 C 45.741276,24.041402 46,24.300705 46,24.620204 V 45.421198 C 46,45.741276 45.741276,46 45.421198,46 z M 30.157605,44.842396 H 44.842396 V 25.199006 H 30.157605 v 19.64339 z" /><text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="31.958805"
+       y="32.467621"
+       id="text3404"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3406"
+         x="31.958805"
+         y="32.467621"
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto">x=2</tspan><tspan
+         id="tspan3412"
+         sodipodi:role="line"
+         x="31.958805"
+         y="41.217621"
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto">y=1</tspan><tspan
+         sodipodi:role="line"
+         x="31.958805"
+         y="49.967621"
+         style="font-size:7px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:Roboto"
+         id="tspan3410" /></text>
+</g><path
+     inkscape:connector-curvature="0"
+     d="m 24.191802,28.646808 4.207656,-4.055036 -4.207656,-4.082252 v 2.367706 H 19.752 v 3.401876 h 4.439802 v 2.367706 z m 3.395143,-4.055036 -2.814777,2.694285 v -1.551255 h -4.439802 v -2.313276 h 4.439802 v -1.551255 l 2.814777,2.721501 z"
+     id="path3097" /></svg>


### PR DESCRIPTION
There are several issues that I'm not sure how to handle:
- one of existiting svg tests fails which breaks all tests. There should probably be some option which would cause the tool to emit error to stderr, and return non-zero return code, but not bail out until all files are processed
- the removal of `style` attribute probably should be a configurable opt-in option
- the whole operation of extracting styles from attributes should probably be a configurable opt-in option
- there should be a way to decide what format should the classnames and selectors have. Care should be taken not to clash with other files. For example if one has files `moon.svg` and 'moon-0.svg'. There are many competing conventions, and I wouldn't like to force `.icon-filename .icon-filename--7` on everyone. Perhaps something like `sprintf` would be cool, so the user could define a format as `.$prefix-$filename--$index` or anything else?
